### PR TITLE
removed deprecated dependency

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,7 +9,7 @@ var gulp = require('gulp'),
  * Ionic Gulp tasks, for more information on each see
  * https://github.com/driftyco/ionic-gulp-tasks
  */
-var buildWebpack = require('ionic-gulp-webpack-build');
+var buildWebpack = require('ionic-gulp-webpack');
 var buildSass = require('ionic-gulp-sass-build');
 var copyHTML = require('ionic-gulp-html-copy');
 var copyFonts = require('ionic-gulp-fonts-copy');

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "ionic-gulp-fonts-copy": "^1.0.0",
     "ionic-gulp-html-copy": "^1.0.0",
     "ionic-gulp-sass-build": "^1.0.0",
-    "ionic-gulp-webpack-build": "^1.0.0",
+    "ionic-gulp-webpack": "^1.0.1",
     "jasmine-core": "2.4.1",
     "jasmine-spec-reporter": "^2.4.0",
     "karma": "0.13.21",


### PR DESCRIPTION
The ionic-gulp-webpack-build plugin is deprecated, added ionic-gulp-webpack