### PR TITLE
Change callback

### DIFF
--- a/test/gulpfile.ts
+++ b/test/gulpfile.ts
@@ -85,7 +85,9 @@ gulp.task('karma', (done: Function) => {
       configFile: join(process.cwd(), TEST_DIR, 'karma.config.js'),
       singleRun: true,
     },
-    done
+    function() {
+      done();
+    }
   ).start();
 });
 


### PR DESCRIPTION
While trying to figure out an issue in my app I introduced a failing test, and got 

```
SUMMARY:
✔ 26 tests completed
✖ 1 test failed

FAILED TESTS:
  ClickerApp
    ✖ initialises with two possible pages
      PhantomJS 2.1.1 (Linux 0.0.0)
    Expected 2 to equal 6.
    /home/mark/Projects/clicker/www/build/test/test.bundle.js:9:9984

[17:05:34] 'karma' errored after 7.4 s
[17:05:34] Error: 1
    at formatError (/home/mark/Projects/clicker/node_modules/gulp/bin/gulp.js:169:10)
    at Gulp.<anonymous> (/home/mark/Projects/clicker/node_modules/gulp/bin/gulp.js:195:15)
    at emitOne (events.js:82:20)
    at Gulp.emit (events.js:169:7)
    at Gulp.Orchestrator._emitTaskDone (/home/mark/Projects/clicker/node_modules/gulp/node_modules/orchestrator/index.js:264:8)
    at /home/mark/Projects/clicker/node_modules/gulp/node_modules/orchestrator/index.js:275:23
    at finish (/home/mark/Projects/clicker/node_modules/gulp/node_modules/orchestrator/lib/runTask.js:21:8)
    at cb (/home/mark/Projects/clicker/node_modules/gulp/node_modules/orchestrator/lib/runTask.js:29:3)
    at removeAllListeners (/home/mark/Projects/clicker/node_modules/karma/lib/server.js:336:7)
    at Server.<anonymous> (/home/mark/Projects/clicker/node_modules/karma/lib/server.js:347:9)
    at Server.g (events.js:260:16)
    at emitNone (events.js:72:20)
    at Server.emit (events.js:166:7)
    at emitCloseNT (net.js:1521:8)
    at nextTickCallbackWith1Arg (node.js:431:9)
    at process._tickCallback (node.js:353:17)
[17:05:34] 'unit-test' errored after 19 s
[17:05:34] Error in plugin 'run-sequence'
Message:
    An error occured in task 'karma'.
npm ERR! Test failed.  See above for more details.
```

I found https://stackoverflow.com/questions/26614738/issue-running-karma-task-from-gulp and made this small change, which seems to improve things.