### PR TITLE
Updated to ionic-conference-app 9d493619 and fixed statusbar overlay shimmering bug on ios.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ branches:
 before_install:
   - nvm use 4.1.2
   - npm install -g cordova ionic
+  - ionic state clear
 
 install: npm install
 
@@ -58,6 +59,8 @@ before_deploy:
   - echo "y" | ./android-sdk-linux/tools/android update sdk --no-ui --filter android-23,build-tools-23.0.1
   - export ANDROID_HOME=${PWD}/android-sdk-linux
   # end install android
+  - ionic state restore
+  - ionic platform add android
   - ionic build android
   # `ionic build android` wraps `cordova build android`, which gives a legit exit code if it fails. Ionic does not; test apk exists.
   - ls ./platforms/android/build/outputs/apk/android*.apk

--- a/config.xml
+++ b/config.xml
@@ -26,10 +26,6 @@
   <feature name="StatusBar">
     <param name="ios-package" onload="true" value="CDVStatusBar"/>
   </feature>
-  <plugin name="cordova-plugin-device" spec="~1.1.2"/>
-  <plugin name="cordova-plugin-console" spec="~1.0.3"/>
-  <plugin name="cordova-plugin-whitelist" spec="~1.2.2"/>
-  <plugin name="cordova-plugin-splashscreen" spec="~3.2.2"/>
-  <plugin name="cordova-plugin-statusbar" spec="~2.1.3"/>
-  <plugin name="ionic-plugin-keyboard" spec="~2.0.1"/>
+  <plugin name="cordova-plugin-whitelist" spec="~1.0.0"/>
+  <plugin name="cordova-sqlite-storage" spec="~1.2.2"/>
 </widget>

--- a/package.json
+++ b/package.json
@@ -5,9 +5,7 @@
     "ionic-angular": "2.0.0-beta.6",
     "ionic-native": "^1.1.0",
     "ionicons": "3.0.0-alpha.3",
-    "reflect-metadata": "0.1.2",
-    "rxjs": "5.0.0-beta.2",
-    "zone.js": "0.6.10"
+    "rxjs": "5.0.0-beta.2"
   },
   "devDependencies": {
     "browserify-istanbul": "^2.0.0",
@@ -17,11 +15,11 @@
     "gulp-tslint": "4.3.5",
     "gulp-typescript": "^2.12.1",
     "gulp-watch": "4.3.5",
-    "ionic-gulp-browserify-typescript": "^1.0.1",
+    "ionic-gulp-browserify-typescript": "^1.1.0",
     "ionic-gulp-fonts-copy": "^1.0.0",
     "ionic-gulp-html-copy": "^1.0.0",
     "ionic-gulp-sass-build": "^1.0.0",
-    "ionic-gulp-scripts-copy": "^1.0.0",
+    "ionic-gulp-scripts-copy": "^1.0.1",
     "isparta": "^4.0.0",
     "jasmine-core": "^2.4.1",
     "jasmine-spec-reporter": "^2.4.0",
@@ -45,18 +43,8 @@
   "name": "clicker",
   "version": "1.2.0",
   "description": "clicker: An Ionic project",
-  "cordovaPlugins": [
-    "cordova-sqlite-storage",
-    "cordova-plugin-device",
-    "cordova-plugin-console",
-    "cordova-plugin-whitelist",
-    "cordova-plugin-splashscreen",
-    "cordova-plugin-statusbar",
-    "ionic-plugin-keyboard"
-  ],
-  "cordovaPlatforms": [
-    "android"
-  ],
+  "cordovaPlugins": [],
+  "cordovaPlatforms": [],
   "scripts": {
     "build": "gulp --gulpfile test/gulpfile.ts --cwd ./ build-app",
     "e2e": "gulp --gulpfile test/gulpfile.ts --cwd ./ build-e2e && protractor test/protractor.conf.js",


### PR DESCRIPTION
- Removed cordova plugins from package.json and added only the necessary ones to the config.xml. **Note**: latest version 1.4.1 of cordova-sqlite-storage gave me a build error for ios. This is why I downgraded to 1.2.2
- Removed as well reflect-metadata and zone.js from package.json and adapted ionic gulp task version.
- Adapted travis-yml as well but you should test em @lathonez  ;-)

![clicker_before](https://cloud.githubusercontent.com/assets/8409778/15267165/485b9330-19ba-11e6-99fd-400998dd2fc8.jpg)
![clickers_after_fix](https://cloud.githubusercontent.com/assets/8409778/15267166/485e56ec-19ba-11e6-94d4-e33e181d63d1.jpg)

