### PR TITLE
More opinions on mock organization 

### DIFF
--- a/app/components/clickerButton/clickerButton.spec.ts
+++ b/app/components/clickerButton/clickerButton.spec.ts
@@ -1,9 +1,16 @@
 import { beforeEach, beforeEachProviders, describe, expect, it }          from '@angular/core/testing';
+import { provide }                                                        from '@angular/core';
 import { asyncCallbackFactory, injectAsyncWrapper, providers, TestUtils } from '../../../test/diExports';
+import { ClickersMock }                                                   from '../../services/mocks';
 import { ClickerButton }                                                  from './clickerButton';
+import { Clickers }                                                       from '../../services';
 
 this.fixture = null;
 this.instance = null;
+
+let clickerButtonProviders: Array<any> = [
+ provide(Clickers, {useClass: ClickersMock}),
+];
 
 describe('ClickerButton', () => {
 
@@ -12,7 +19,7 @@ describe('ClickerButton', () => {
     testSpec.instance['clicker'].getCount = function(): number { return 10; };
   });
 
-  beforeEachProviders(() => providers);
+  beforeEachProviders(() => providers.concat(clickerButtonProviders));
   beforeEach(injectAsyncWrapper(asyncCallbackFactory(ClickerButton, this, false, beforeEachFn)));
 
   it('initialises', () => {

--- a/app/components/clickerForm/clickerForm.spec.ts
+++ b/app/components/clickerForm/clickerForm.spec.ts
@@ -1,10 +1,16 @@
 import { beforeEach, beforeEachProviders, describe, expect, it }          from '@angular/core/testing';
+import { provide }                                                        from '@angular/core';
 import { asyncCallbackFactory, injectAsyncWrapper, providers, TestUtils } from '../../../test/diExports';
-import { Utils }                                                          from '../../services/utils';
+import { ClickersMock }                                                   from '../../services/mocks';
+import { Clickers, Utils }                                                from '../../services';
 import { ClickerForm }                                                    from './clickerForm';
 
 this.fixture = null;
 this.instance = null;
+
+let clickerFormProviders: Array<any> = [
+ provide(Clickers, {useClass: ClickersMock}),
+];
 
 describe('ClickerForm', () => {
 
@@ -13,7 +19,7 @@ describe('ClickerForm', () => {
     spyOn(testSpec.instance['clickerService'], 'newClicker').and.callThrough();
   });
 
-  beforeEachProviders(() => providers);
+  beforeEachProviders(() => providers.concat(clickerFormProviders));
   beforeEach(injectAsyncWrapper(asyncCallbackFactory(ClickerForm, this, false, beforeEachFn)));
 
   it('initialises', () => {

--- a/app/components/clickerForm/clickerForm.ts
+++ b/app/components/clickerForm/clickerForm.ts
@@ -3,8 +3,7 @@
 import { AbstractControl, ControlGroup, FormBuilder, Validators } from '@angular/common';
 import { Component }                                              from '@angular/core';
 import { Button, Icon, Item, Label, TextInput }                   from 'ionic-angular';
-import { Clickers }                                               from '../../services/clickers';
-import { Utils }                                                  from '../../services/utils';
+import { Clickers, Utils }                                        from '../../services';
 
 @Component({
   selector: 'clicker-form',

--- a/app/pages/clickerList/clickerList.spec.ts
+++ b/app/pages/clickerList/clickerList.spec.ts
@@ -1,13 +1,20 @@
 import { beforeEach, beforeEachProviders, describe, expect, it } from '@angular/core/testing';
+import { provide }                                               from '@angular/core';
 import { asyncCallbackFactory, injectAsyncWrapper, providers }   from '../../../test/diExports';
+import { ClickersMock }                                          from '../../services/mocks';
 import { ClickerList }                                           from './clickerList';
+import { Clickers }                                              from '../../services';
 
 this.fixture = null;
 this.instance = null;
 
+let clickerListProviders: Array<any> = [
+ provide(Clickers, {useClass: ClickersMock}),
+];
+
 describe('ClickerList', () => {
 
-  beforeEachProviders(() => providers);
+  beforeEachProviders(() => providers.concat(clickerListProviders));
   beforeEach(injectAsyncWrapper(asyncCallbackFactory(ClickerList, this, true)));
 
   it('initialises', () => {

--- a/app/pages/clickerList/clickerList.ts
+++ b/app/pages/clickerList/clickerList.ts
@@ -2,7 +2,7 @@
 
 import { Component }     from '@angular/core';
 import { NavController } from 'ionic-angular';
-import { Clickers }      from '../../services/clickers';
+import { Clickers }      from '../../services';
 import { ClickerButton } from '../../components/clickerButton/clickerButton';
 import { ClickerForm }   from '../../components/clickerForm/clickerForm';
 

--- a/app/services/clickers.mock.ts
+++ b/app/services/clickers.mock.ts
@@ -1,0 +1,16 @@
+// CLICKERS:
+
+export class ClickersMock {
+  public doClick(): boolean {
+    return true;
+  }
+
+  public newClicker(): boolean {
+    return true;
+  }
+}
+
+export class ClickerMock {
+  public name: string = 'TEST CLICKER';
+  public getCount(): number { return 10; };
+}

--- a/app/services/index.ts
+++ b/app/services/index.ts
@@ -1,0 +1,2 @@
+export * from './clickers';
+export * from './utils';

--- a/app/services/mocks.ts
+++ b/app/services/mocks.ts
@@ -1,0 +1,1 @@
+export * from './clickers.mock';

--- a/test/diExports.ts
+++ b/test/diExports.ts
@@ -3,15 +3,13 @@ import { ComponentFixture, TestComponentBuilder }     from '@angular/compiler/te
 import { injectAsync }                                from '@angular/core/testing';
 import { Control }                                    from '@angular/common';
 import { App, Config, Form, NavController, Platform } from 'ionic-angular';
-import { ClickersMock, ConfigMock, NavMock }          from './mocks';
+import { ConfigMock, NavMock }                        from './mocks';
 import { Utils }                                      from '../app/services/utils';
-import { Clickers }                                   from '../app/services/clickers';
 export { TestUtils }                                  from './testUtils';
 
 export let providers: Array<any> = [
   Form,
   provide(Config, {useClass: ConfigMock}),
-  provide(Clickers, {useClass: ClickersMock}), // required by ClickerButton
   provide(App, {useClass: ConfigMock}),        // required by ClickerList
   provide(NavController, {useClass: NavMock}), // required by ClickerList
   provide(Platform, {useClass: ConfigMock}),   // -> IonicApp

--- a/test/mocks.ts
+++ b/test/mocks.ts
@@ -1,19 +1,3 @@
-// CLICKERS:
-
-export class ClickersMock {
-  public doClick(): boolean {
-    return true;
-  }
-
-  public newClicker(): boolean {
-    return true;
-  }
-}
-
-export class ClickerMock {
-  public name: string = 'TEST CLICKER';
-  public getCount(): number { return 10; };
-}
 
 // IONIC:
 


### PR DESCRIPTION
@lathonez the reorg (https://github.com/lathonez/clicker/issues/103) minimizes boilerplate, but please consider this alternative.  For my app at least, putting all of the public methods for 30+ services in a single file is impracticable.  When testing services consumed by multiple components, moving the mock out of the spec is DRYer.   Ionic/platform mocks are still centrally in the `test/mocks.ts` but service mocks are in the same directory as the implementation.

To make life easier I'm using  [barrels ](https://johnpapa.net/angular-2-styles/#barrel) to provide encapsulation of services [(definition)](https://github.com/lathonez/clicker/compare/master...kwv:master#diff-816d8d4dbe0521fa5deaff9a5ab4ce61R1) [(import)](https://github.com/lathonez/clicker/compare/master...kwv:master#diff-c8d5c04b82ea2e74a306a5151f197496R6)

I think the same approach makes [importing mocks](https://github.com/lathonez/clicker/compare/master...kwv:master#diff-a20b2d2b60065b5e2f29e8149b872a3dR4) easy as well

```
services/
   - index.ts /* barrel of all subfolders */
   - clickers/    
      - clickers.service.ts
      - clickers.mock.ts
      - clickers.spec.ts
   - mocks.ts /* barrel of all mocks within subfolders */
```



