### PR TITLE
reproducing No value for accessor '' error in issue 108

### DIFF
--- a/app/pages/page2/page2.html
+++ b/app/pages/page2/page2.html
@@ -9,8 +9,11 @@
 
 <ion-content padding class="message bye-ionic">
   <h2>Bye!</h2>
-  <!-- NOTE: tried it with either <ion-range> or <ion-input> and
-       both produce the error " No value accessor for '' " -->
+  <!-- NOTE: the clicker issue 108 error can be reproduced either with
+       an <ion-range> or with an <ion-input> element with an
+       [(ngModel)]. uncomment either one of those lines and uncomment
+       the corresponding lines in page2.ts that change the type of
+       'value' -->
   <!--ion-range [(ngModel)]="value"></ion-range-->
   <ion-input [(ngModel)]="value" type="text"></ion-input>
 </ion-content>

--- a/app/pages/page2/page2.html
+++ b/app/pages/page2/page2.html
@@ -9,4 +9,8 @@
 
 <ion-content padding class="message bye-ionic">
   <h2>Bye!</h2>
+  <!-- NOTE: tried it with either <ion-range> or <ion-input> and
+       both produce the error " No value accessor for '' " -->
+  <!--ion-range [(ngModel)]="value"></ion-range-->
+  <ion-input [(ngModel)]="value" type="text"></ion-input>
 </ion-content>

--- a/app/pages/page2/page2.ts
+++ b/app/pages/page2/page2.ts
@@ -6,10 +6,15 @@ import {Component} from '@angular/core';
   templateUrl: 'build/pages/page2/page2.html',
 })
 export class Page2 {
-  private value: any;
+  // NOTE: reproducing clicker issue 108: 'value' should be a string
+  // type if you uncommented the <ion-input> line in page2.html, or
+  // if you uncommented <ion-range>, then 'value' should be an int
+
+  // private value: number;
+  private value: string;
   constructor() {
-    // NOTE: use number value if uncommenting <ion-range> in template
-    // or use string value if uncommenting <ion-input> in template
+
+use number value if uncommenting <ion-range> in template
     // this.value = 33;
     this.value = 'some text';
   }

--- a/app/pages/page2/page2.ts
+++ b/app/pages/page2/page2.ts
@@ -6,7 +6,11 @@ import {Component} from '@angular/core';
   templateUrl: 'build/pages/page2/page2.html',
 })
 export class Page2 {
+  private value: number;
   constructor() {
-    // no-op
+    this.value = 33;
+  }
+  public onGainChange(arg: any): void {
+      return;
   }
 }

--- a/app/pages/page2/page2.ts
+++ b/app/pages/page2/page2.ts
@@ -6,9 +6,12 @@ import {Component} from '@angular/core';
   templateUrl: 'build/pages/page2/page2.html',
 })
 export class Page2 {
-  private value: number;
+  private value: any;
   constructor() {
-    this.value = 33;
+    // NOTE: use number value if uncommenting <ion-range> in template
+    // or use string value if uncommenting <ion-input> in template
+    // this.value = 33;
+    this.value = 'some text';
   }
   public onGainChange(arg: any): void {
       return;

--- a/app/pages/page2/page2.ts
+++ b/app/pages/page2/page2.ts
@@ -14,7 +14,6 @@ export class Page2 {
   private value: string;
   constructor() {
 
-use number value if uncommenting <ion-range> in template
     // this.value = 33;
     this.value = 'some text';
   }


### PR DESCRIPTION
These changes reproduce the problem discussed in issue 108, they do not fix anything.

The only difference I see between the [(ngModel)] use here, in Page2 (which fails) and the [(ngModel)] use in ClickerForm (which does not fail) is that here it is used in the template of a page component and there it is in a template of a (non-page) component, obviously... The problem I had in my project, too, was in the the template of a page.

