### PR TITLE
Remove file extensions on pages/index.ts

### DIFF
--- a/app/pages/index.ts
+++ b/app/pages/index.ts
@@ -1,2 +1,2 @@
-export * from './clickerList/clickerList.ts';
-export * from './page2/page2.ts';
+export * from './clickerList/clickerList';
+export * from './page2/page2';


### PR DESCRIPTION
Besides being unnecessary, the extensions causes problems when using Wallaby.js. And are probably a problem in similar situations. You can see the issue on the Wallaby repo here https://github.com/wallabyjs/public/issues/620