### PR TITLE
Using karma custom template properties to override HTMLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "build": "gulp --gulpfile test/gulpfile.ts --cwd ./ build-app",
     "e2e": "gulp --gulpfile test/gulpfile.ts --cwd ./ build-e2e && protractor test/protractor.conf.js",
     "karma": "gulp --gulpfile test/gulpfile.ts --cwd ./ karma-debug",
-    "postinstall": "ionic state restore && typings install && webdriver-manager update && cp test/karma-static/*.html node_modules/karma/static",
+    "postinstall": "ionic state restore && typings install && webdriver-manager update",
     "start": "ionic serve",
     "test": "gulp --gulpfile test/gulpfile.ts --cwd ./ unit-test"
   },

--- a/test/karma.config.js
+++ b/test/karma.config.js
@@ -87,7 +87,12 @@ module.exports = function(config) {
 
     // https://github.com/lathonez/clicker/issues/82
     // try increasing this value if you see the error "Disconnected (1 times), because no message in 30000 ms."
-    browserNoActivityTimeout: 30000
+    browserNoActivityTimeout: 30000,
+
+    customContextFile: "test/karma-static/context.html",
+
+    customDebugFile: "test/karma-static/debug.html",
+
   });
 
   if (process.env.TRAVIS || process.env.CIRCLECI) {


### PR DESCRIPTION
Hi,

This pull request changes the way the Karma context and debug HTML files are replaced. 

Instead of copying the custom HTML files to Karma install, it uses Karma's customContextFile and customDebugFile properties to tell Karma to use HTML files with <ion-app></ion-app> tags.

Thanks,
Lazaro