### PR TITLE
removed the browserify transform

### DIFF
--- a/test/gulpfile.ts
+++ b/test/gulpfile.ts
@@ -74,7 +74,8 @@ gulp.task('karma-debug', (done: Function) => {
     browsers: ['Chrome'],
     reporters: ['mocha'],
     browserify: {
-      debug: true,
+      debug: true,            
+      transform : [],
       plugin: [
         ['tsify'],
       ],


### PR DESCRIPTION
If you want to enable Chrome debugging in Gulp task karma-debug, I suppose you want to disable the code coverage ?