### PR TITLE
Service & mock passed from component instead of adding in test.ts

### DIFF
--- a/src/components/clickerButton/clickerButton.spec.ts
+++ b/src/components/clickerButton/clickerButton.spec.ts
@@ -2,13 +2,17 @@ import { ComponentFixture, async } from '@angular/core/testing';
 import { TestUtils }               from '../../test';
 import { ClickerButton }           from './clickerButton';
 import { ClickerMock }             from '../../models/clicker.mock';
+import { ClickersServiceMock } from '../../services/clickers.mock';
+import { ClickersService } from '../../services';
 
 let fixture: ComponentFixture<ClickerButton> = null;
 let instance: any = null;
 
 describe('ClickerButton', () => {
 
-  beforeEach(async(() => TestUtils.beforeEachCompiler([ClickerButton]).then(compiled => {
+  beforeEach(async(() => TestUtils.beforeEachCompiler([ClickerButton],[
+    {provide: ClickersService, useClass: ClickersServiceMock}
+    ]).then(compiled => {
     fixture = compiled.fixture;
     instance = compiled.instance;
     instance.clicker = new ClickerMock();

--- a/src/components/clickerForm/clickerForm.spec.ts
+++ b/src/components/clickerForm/clickerForm.spec.ts
@@ -2,13 +2,17 @@ import { FormBuilder }             from '@angular/forms';
 import { ComponentFixture, async } from '@angular/core/testing';
 import { TestUtils }               from '../../test';
 import { ClickerForm }             from './clickerForm';
+import { ClickersServiceMock } from '../../services/clickers.mock';
+import { ClickersService } from '../../services';
 
 let fixture: ComponentFixture<ClickerForm> = null;
 let instance: any = null;
 
 describe('ClickerForm', () => {
 
-  beforeEach(async(() => TestUtils.beforeEachCompiler([ClickerForm]).then(compiled => {
+  beforeEach(async(() => TestUtils.beforeEachCompiler([ClickerForm], [
+    {provide: ClickersService, useClass: ClickersServiceMock}
+    ]).then(compiled => {
     fixture = compiled.fixture;
     instance = compiled.instance;
     instance.clicker = { name: 'TEST CLICKER' };

--- a/src/pages/clickerList/clickerList.spec.ts
+++ b/src/pages/clickerList/clickerList.spec.ts
@@ -2,13 +2,17 @@ import { ComponentFixture, async }    from '@angular/core/testing';
 import { TestUtils }                  from '../../test';
 import { ClickerList }                from './clickerList';
 import { ClickerButton, ClickerForm } from '../../components';
+import { ClickersServiceMock } from '../../services/clickers.mock';
+import { ClickersService } from '../../services';
 
 let fixture: ComponentFixture<ClickerList> = null;
 let instance: any = null;
 
 describe('ClickerList', () => {
 
-  beforeEach(async(() => TestUtils.beforeEachCompiler([ClickerList, ClickerForm, ClickerButton]).then(compiled => {
+  beforeEach(async(() => TestUtils.beforeEachCompiler([ClickerList, ClickerForm, ClickerButton], [
+    {provide: ClickersService, useClass: ClickersServiceMock}
+    ]).then(compiled => {
     fixture = compiled.fixture;
     instance = compiled.instance;
     fixture.detectChanges();

--- a/src/test.ts
+++ b/src/test.ts
@@ -11,8 +11,6 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { TestBed } from '@angular/core/testing';
 import { App, MenuController, NavController, Platform, Config, Keyboard, Form, IonicModule }  from 'ionic-angular';
 import { ConfigMock } from './mocks';
-import { ClickersServiceMock } from './services/clickers.mock';
-import { ClickersService } from './services';
 
 // Unfortunately there's no typing for the `__karma__` variable. Just declare it as any.
 declare var __karma__: any;
@@ -41,8 +39,8 @@ Promise.all([
 
 export class TestUtils {
 
-  public static beforeEachCompiler(components: Array<any>): Promise<{fixture: any, instance: any}> {
-    return TestUtils.configureIonicTestingModule(components)
+  public static beforeEachCompiler(components: Array<any>, overrideProviders: Array<any> = []): Promise<{fixture: any, instance: any}> {
+    return TestUtils.configureIonicTestingModule(components, overrideProviders)
       .compileComponents().then(() => {
         let fixture: any = TestBed.createComponent(components[0]);
         return {
@@ -52,22 +50,26 @@ export class TestUtils {
       });
   }
 
-  public static configureIonicTestingModule(components: Array<any>): typeof TestBed {
+  public static configureIonicTestingModule(components: Array<any>, overrideProviders: Array<any>): typeof TestBed {
     return TestBed.configureTestingModule({
       declarations: [
         ...components,
       ],
       providers: [
         App, Platform, Form, Keyboard, MenuController, NavController,
-        {provide: Config, useClass: ConfigMock},
-        {provide: ClickersService, useClass: ClickersServiceMock},
+        {provide: Config, useClass: ConfigMock}
       ],
       imports: [
         FormsModule,
         IonicModule,
         ReactiveFormsModule,
       ],
-    });
+    })
+    .overrideComponent(components[0], {
+      set: {
+        providers: [...overrideProviders]
+      }
+    })
   }
 
   // http://stackoverflow.com/questions/2705583/how-to-simulate-a-click-with-javascript


### PR DESCRIPTION
Hey @lathonez,

I understand all your components and pages require clickerService and hence you set the service and its mock in test.ts itself.

As your blog is used as the reference to "How to add unit testing in ionic 2", those who are new to this might get confused by seeing the custom services and mocks added in the test.ts

The changes done in this PR allow the devs to pass the provider and mock from the component rather than setting it up in the test.ts, For some larger apps, it will keep the test.ts clean as well.

I think my changes might avoid this confusion. (May be I was the only one had that confusion).

Please check this and let me you know your thoughts.